### PR TITLE
Enforce chat conversation role

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ async function main() {
         content: 'this is the start',
       },
       {
-        role: 'opper',
+        role: 'assistant',
         content: 'this is response',
       },
       {

--- a/src/__tests__/api-resource.test.ts
+++ b/src/__tests__/api-resource.test.ts
@@ -136,12 +136,12 @@ describe('APIResource', () => {
     it('should format an array of OpperAIChatConversation as a conversation', () => {
       const message = [
         { role: 'user', content: 'Hello, world!' },
-        { role: 'bot', content: 'Hi there!' },
+        { role: 'assistant', content: 'Hi there!' },
       ];
       // @ts-expect-error Testing protected prop
       const formattedMessage = apiResource.calcMessageForPost(message);
       expect(formattedMessage).toBe(
-        '{"messages":[{"role":"user","content":"Hello, world!"},{"role":"bot","content":"Hi there!"}]}'
+        '{"messages":[{"role":"user","content":"Hello, world!"},{"role":"assistant","content":"Hi there!"}]}'
       );
     });
 
@@ -164,6 +164,13 @@ describe('APIResource', () => {
 
     it('should return false for an invalid OpperAIChatConversation object', () => {
       const conversation = { role: 'user', something: 'Hello, world!' };
+      // @ts-expect-error Testing protected prop
+      const result = apiResource.isOpperAIChatConversation(conversation);
+      expect(result).toBe(false);
+    });
+
+    it('should return false if the role is incorrect', () => {
+      const conversation = { role: 'wrong', content: 'Hello, world!' };
       // @ts-expect-error Testing protected prop
       const result = apiResource.isOpperAIChatConversation(conversation);
       expect(result).toBe(false);

--- a/src/opperai-api-resource.ts
+++ b/src/opperai-api-resource.ts
@@ -207,7 +207,14 @@ class OpperAIAPIResource {
 
   // Safe type test for the OpperAIChatConversation type
   protected isOpperAIChatConversation(m: unknown): m is OpperAIChatConversation {
-    return m !== null && typeof m === 'object' && 'role' in m && 'content' in m;
+    const candidate = m as OpperAIChatConversation; // Type assertion to an intermediate type
+    return (
+      typeof m === 'object' &&
+      m !== null &&
+      typeof candidate.role === 'string' &&
+      ['assistant', 'user'].includes(candidate.role) &&
+      'content' in candidate
+    );
   }
 
   // Format post body

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export type OpperAIOptions = {
 };
 
 export type OpperAIChatConversation = {
-  role: string;
+  role: 'user' | 'assistant';
   content: string;
 };
 


### PR DESCRIPTION
- Update type of OpperAIChatConversation role to be 'user' | 'assistant'
- Update apiResource.isOpperAIChatConversation to enforce role type