### PR TITLE
Limit examples length to 10

### DIFF
--- a/src/__tests__/opperai-functions.test.ts
+++ b/src/__tests__/opperai-functions.test.ts
@@ -1,7 +1,7 @@
 import { APIError } from "../errors";
 import Functions from "../functions";
 import Client from "../index";
-import { OpperCall, OpperCallExample } from "../types";
+import { OpperCall } from "../types";
 
 // Mocking the global fetch to avoid actual API calls
 // @ts-expect-error Mocking global fetch
@@ -147,7 +147,7 @@ describe("OpperAIFunctions", () => {
             const functionCall: OpperCall = {
                 name: "testFunction",
                 input: "Test input",
-                examples: new Array(10).fill({ input: "test", output: "test" }) as OpperCallExample,
+                examples: new Array(10).fill({ input: "test", output: "test" }),
             };
 
             await functions.call(functionCall);
@@ -165,7 +165,7 @@ describe("OpperAIFunctions", () => {
             const functionCall: OpperCall = {
                 name: "testFunction",
                 input: "Test input",
-                examples: new Array(11).fill({ input: "test", output: "test" }) as OpperCallExample,
+                examples: new Array(11).fill({ input: "test", output: "test" }),
             };
 
             await expect(functions.call(functionCall)).rejects.toThrow(

--- a/src/api-resource.ts
+++ b/src/api-resource.ts
@@ -256,7 +256,7 @@ class APIResource {
     ) {
         return {
             messages: this.calcMessagesForPost(messages),
-            parent_span_uuid: parent_span_uuid,
+            parent_span_uuid,
             examples: examples?.map(({ input, output, comment }) => ({
                 input: stringify(input) ?? undefined,
                 output: stringify(output) ?? undefined,

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -6,6 +6,7 @@ import {
     OpperImageResponse,
     Chat,
     OpperAIStream,
+    OpperExample,
 } from "./types";
 
 import APIResource from "./api-resource";
@@ -27,8 +28,12 @@ class Functions extends APIResource {
         parent_span_uuid,
         examples,
     }: Chat): Promise<OpperChatResponse> {
+        if (examples && Array.isArray(examples) && examples.length > 10) {
+            throw new OpperError("Maximum number of examples is 10");
+        }
+
         const url = this.calcURLChat(path);
-        const body = this.calcChatPayload(message, parent_span_uuid, examples);
+        const body = this.calcChatPayload(message, parent_span_uuid, examples as OpperExample[]);
 
         const response = await this.doPost(url, body);
 
@@ -80,6 +85,10 @@ class Functions extends APIResource {
      * @throws {OpperError} If the function already exists and update is false.
      */
     public async call(fn: OpperCall): Promise<OpperChatResponse> {
+        if (fn.examples && Array.isArray(fn.examples) && fn.examples.length > 10) {
+            throw new OpperError("Maximum number of examples is 10");
+        }
+
         const response = await this.doPost(this.calcURLCall(), {
             ...fn,
             input_type: fn?.input_schema,

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -6,7 +6,6 @@ import {
     OpperImageResponse,
     Chat,
     OpperAIStream,
-    OpperExample,
 } from "./types";
 
 import APIResource from "./api-resource";
@@ -33,7 +32,7 @@ class Functions extends APIResource {
         }
 
         const url = this.calcURLChat(path);
-        const body = this.calcChatPayload(message, parent_span_uuid, examples as OpperExample[]);
+        const body = this.calcChatPayload(message, parent_span_uuid, examples);
 
         const response = await this.doPost(url, body);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,11 @@ export interface Chat {
     parent_span_uuid?: string;
     path: string;
     message: string | Message[];
-    examples?: OpperExample[];
+    /**
+     * Manual examples to use as part of the prompt to guide the model.
+     * There is a hard limit of 10 examples.
+     */
+    examples?: OpperCallExample;
 }
 
 export interface SSEStreamCallbacks {
@@ -123,6 +127,19 @@ export type OpperExample = {
     comment?: string;
 };
 
+export type OpperCallExample = [
+    OpperExample?,
+    OpperExample?,
+    OpperExample?,
+    OpperExample?,
+    OpperExample?,
+    OpperExample?,
+    OpperExample?,
+    OpperExample?,
+    OpperExample?,
+    OpperExample?,
+];
+
 export interface OpperGenerateImage {
     prompt: string;
     model?: string;
@@ -171,8 +188,9 @@ export type OpperCall = {
 
     /**
      * Manual examples to use as part of the prompt to guide the model.
+     * There is a hard limit of 10 examples.
      */
-    examples?: OpperExample[];
+    examples?: OpperCallExample;
 
     /**
      * Whether to stream the response from the function.

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export interface Chat {
      * Manual examples to use as part of the prompt to guide the model.
      * There is a hard limit of 10 examples.
      */
-    examples?: OpperCallExample;
+    examples?: OpperExample[];
 }
 
 export interface SSEStreamCallbacks {
@@ -127,19 +127,6 @@ export type OpperExample = {
     comment?: string;
 };
 
-export type OpperCallExample = [
-    OpperExample?,
-    OpperExample?,
-    OpperExample?,
-    OpperExample?,
-    OpperExample?,
-    OpperExample?,
-    OpperExample?,
-    OpperExample?,
-    OpperExample?,
-    OpperExample?,
-];
-
 export interface OpperGenerateImage {
     prompt: string;
     model?: string;
@@ -190,7 +177,7 @@ export type OpperCall = {
      * Manual examples to use as part of the prompt to guide the model.
      * There is a hard limit of 10 examples.
      */
-    examples?: OpperCallExample;
+    examples?: OpperExample[];
 
     /**
      * Whether to stream the response from the function.


### PR DESCRIPTION
- Limit the amount of examples the user can send as part of a function call to 10