### PR TITLE
Allow a child span to start with a given parent span

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,22 @@ await trace.end({
 });
 ```
 
+Manually create a child span for a given parent trace/span:
+
+```typescript
+const manualSpan = await client.traces.startSpan({
+    parent_uuid: trace.uuid,
+    name: "example-span",
+    input: "example input",
+});
+
+await manualSpan.end({
+    output: "example output",
+});
+```
+
+See [example-tracing-manual.ts](./examples/example-tracing-manual.ts) for a full example of how to manually create spans including saving metrics and examples.
+
 ### Datasets
 
 See [example-datasets.ts](./examples/example-datasets.ts):

--- a/examples/example-tracing-manual.ts
+++ b/examples/example-tracing-manual.ts
@@ -2,6 +2,7 @@
 // Run example with "npx ts-node ./examples/example-tracing-manual.ts"
 import "dotenv/config";
 import Client from "../src";
+import { nanoId } from "../src/utils";
 
 // Your API key will be loaded from the environment variable OPPER_API_KEY if not provided
 const client = new Client();
@@ -55,6 +56,17 @@ const sleepAndReturn = async (ms: number, returnValue: any) => {
     await span.end({
         output: { foo: "bar" },
     });
+
+    // Manually create a new child span for a given trace with a its uuid
+    const manualSpan = await client.traces.startSpan({
+        // A custom uuid can be provided for the span
+        uuid: nanoId(),
+        parent_uuid: trace.uuid,
+        name: "node-sdk/tracing-manual/manual-span",
+        input: { some: "input given to", to: "the manual span" },
+    });
+    await sleepAndReturn(1000, null);
+    await manualSpan.end({ output: { foo: "bar" } });
 
     await trace.end({ output: { foo: "bar" } });
 })();

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -70,33 +70,33 @@ describe("OpperAIClient", () => {
                 message: "test response",
                 context: {},
                 span_id: "test-span-id",
-                json_payload: { sum: 30 }
+                json_payload: { sum: 30 },
             });
 
             const response = await client.functions.call({
                 name: "test-function",
                 input: {
                     x: 10,
-                    y: 20
+                    y: 20,
                 },
                 tags: {
                     environment: "test",
                     feature: "arithmetic",
-                    version: "1.0.0"
-                }
+                    version: "1.0.0",
+                },
             });
 
             expect(callSpy).toHaveBeenCalledWith({
                 name: "test-function",
                 input: {
                     x: 10,
-                    y: 20
+                    y: 20,
                 },
                 tags: {
                     environment: "test",
                     feature: "arithmetic",
-                    version: "1.0.0"
-                }
+                    version: "1.0.0",
+                },
             });
 
             expect(response.json_payload).toEqual({ sum: 30 });

--- a/src/__tests__/opperai-indexes.test.ts
+++ b/src/__tests__/opperai-indexes.test.ts
@@ -102,14 +102,17 @@ describe("OpperAIIndexes", () => {
             expect(index?.uuid).toBe(mockIndex.uuid);
             expect(index?._index).toEqual(mockIndex);
             expect(fetch).toHaveBeenCalledTimes(1);
-            expect(fetch).toHaveBeenCalledWith("https://api.opper.ai/v1/indexes/by-name/Test%20Index%201", {
-                method: "GET",
-                headers: {
-                    "X-OPPER-API-KEY": "test-api-key",
-                    "User-Agent": "opper-node/0.0.0",
-                    "Content-Type": "application/json",
-                },
-            });
+            expect(fetch).toHaveBeenCalledWith(
+                "https://api.opper.ai/v1/indexes/by-name/Test%20Index%201",
+                {
+                    method: "GET",
+                    headers: {
+                        "X-OPPER-API-KEY": "test-api-key",
+                        "User-Agent": "opper-node/0.0.0",
+                        "Content-Type": "application/json",
+                    },
+                }
+            );
         });
 
         it("should return null when index is not found", async () => {
@@ -123,14 +126,17 @@ describe("OpperAIIndexes", () => {
 
             expect(index).toBeNull();
             expect(fetch).toHaveBeenCalledTimes(1);
-            expect(fetch).toHaveBeenCalledWith("https://api.opper.ai/v1/indexes/by-name/NonExistentIndex", {
-                method: "GET",
-                headers: {
-                    "X-OPPER-API-KEY": "test-api-key",
-                    "User-Agent": "opper-node/0.0.0",
-                    "Content-Type": "application/json",
-                },
-            });
+            expect(fetch).toHaveBeenCalledWith(
+                "https://api.opper.ai/v1/indexes/by-name/NonExistentIndex",
+                {
+                    method: "GET",
+                    headers: {
+                        "X-OPPER-API-KEY": "test-api-key",
+                        "User-Agent": "opper-node/0.0.0",
+                        "Content-Type": "application/json",
+                    },
+                }
+            );
         });
 
         it("should throw an error for non-404 errors", async () => {
@@ -165,14 +171,18 @@ describe("OpperAIIndexes", () => {
             expect(result).toBe(true);
             expect(fetch).toHaveBeenCalledTimes(2);
             // Verify get request
-            expect(fetch).toHaveBeenNthCalledWith(1, "https://api.opper.ai/v1/indexes/by-name/Test%20Index%201", {
-                method: "GET",
-                headers: {
-                    "X-OPPER-API-KEY": "test-api-key",
-                    "User-Agent": "opper-node/0.0.0",
-                    "Content-Type": "application/json",
-                },
-            });
+            expect(fetch).toHaveBeenNthCalledWith(
+                1,
+                "https://api.opper.ai/v1/indexes/by-name/Test%20Index%201",
+                {
+                    method: "GET",
+                    headers: {
+                        "X-OPPER-API-KEY": "test-api-key",
+                        "User-Agent": "opper-node/0.0.0",
+                        "Content-Type": "application/json",
+                    },
+                }
+            );
             // Verify delete request
             expect(fetch).toHaveBeenNthCalledWith(2, "https://api.opper.ai/v1/indexes/1", {
                 method: "DELETE",

--- a/src/traces.ts
+++ b/src/traces.ts
@@ -39,9 +39,11 @@ export class OpperTrace extends APIResource {
         name = "mising_name",
         input,
         start_time = new Date(),
+        uuid = nanoId(),
         metadata,
-    }: SpanStartOptions) {
-        const uuid = nanoId();
+    }: SpanStartOptions & {
+        uuid?: string;
+    }) {
         const parent_uuid = this.uuid;
         const url = this.calcBaseURL();
 
@@ -127,6 +129,38 @@ class Traces extends APIResource {
         });
 
         return new OpperTrace({ uuid: data.uuid }, this);
+    }
+
+    /**
+     * Manually create a new child span of a given trace.
+     */
+    public async startSpan({
+        uuid,
+        parent_uuid,
+        name = "mising_name",
+        input,
+        start_time = new Date(),
+        metadata,
+    }: SpanStartOptions & {
+        /**
+         * The uuid of the span to be created.
+         * If not provided, a new uuid will be generated.
+         */
+        uuid?: string;
+        /**
+         * The uuid of the parent span.
+         */
+        parent_uuid: string;
+    }) {
+        const trace = new OpperTrace({ uuid: parent_uuid }, this);
+
+        return trace.startSpan({
+            name,
+            input,
+            start_time,
+            metadata,
+            uuid,
+        });
     }
 }
 


### PR DESCRIPTION
Allow the user to manually create a child span for a given parent trace/span:

```typescript
const manualSpan = await client.traces.startSpan({
    parent_uuid: trace.uuid,
    name: "example-span",
    input: "example input",
});

await manualSpan.end({
    output: "example output",
});
```