### PR TITLE
Fix Zod peer dependency range

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,28 +54,28 @@ The SDK can be installed with either [npm](https://www.npmjs.com/), [pnpm](https
 ### NPM
 
 ```bash
-npm add opperai zod@^3.23.8
+npm add opperai
 ```
 
 ### PNPM
 
 ```bash
-pnpm add opperai zod@^3.23.8
+pnpm add opperai
 ```
 
 ### Bun
 
 ```bash
-bun add opperai zod@^3.23.8
+bun add opperai
 ```
 
 ### Yarn
 
 ```bash
-yarn add opperai zod@^3.23.8
+yarn add opperai
 
-# Note that Yarn does not install peer dependencies automatically. You will need
-# to install zod v3.x, as shown above.
+# Note that Yarn does not install peer dependencies automatically. Run
+# `yarn add zod@^3.23.8` as well if you haven't already.
 ```
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -54,29 +54,32 @@ The SDK can be installed with either [npm](https://www.npmjs.com/), [pnpm](https
 ### NPM
 
 ```bash
-npm add opperai
+npm add opperai zod@^3.23.8
 ```
 
 ### PNPM
 
 ```bash
-pnpm add opperai
+pnpm add opperai zod@^3.23.8
 ```
 
 ### Bun
 
 ```bash
-bun add opperai
+bun add opperai zod@^3.23.8
 ```
 
 ### Yarn
 
 ```bash
-yarn add opperai zod
+yarn add opperai zod@^3.23.8
 
 # Note that Yarn does not install peer dependencies automatically. You will need
-# to install zod as shown above.
+# to install zod v3.x, as shown above.
 ```
+
+> [!IMPORTANT]
+> This SDK currently supports Zod v3.x. Ensure your project installs `zod@^3.23.8` (or another `3.x` release) and avoids Zod v4 releases.
 
 > [!NOTE]
 > This package is published with CommonJS and ES Modules (ESM) support.

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "opperai",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "opperai",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "opperai",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "bin": {
                 "mcp": "bin/mcp-server.js"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
             },
             "peerDependencies": {
                 "@modelcontextprotocol/sdk": ">=1.5.0 <1.10.0",
-                "zod": ">= 3"
+                "zod": ">=3.23.8 <4"
             },
             "peerDependenciesMeta": {
                 "@modelcontextprotocol/sdk": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     },
     "peerDependencies": {
         "@modelcontextprotocol/sdk": ">=1.5.0 <1.10.0",
-        "zod": ">= 3"
+        "zod": ">=3.23.8 <4"
     },
     "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "opperai",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "author": "Speakeasy",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Summary
- tighten the Zod peer dependency to >=3.23.8 <4
- update install instructions to pin zod@^3.23.8 and warn about v4

## Testing
- not run (docs-only)